### PR TITLE
Adding section customization

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import Renderer_0_3, { // eslint-disable-line
 // ///////////////////////////////////////
 
 export default class MobiledocReactRenderer {
-  constructor ({ sections = [], atoms = [], cards = [], markups = [] }) {
+  constructor ({ sections = {}, atoms = [], cards = [], markups = [] }) {
     this.options = {
       sections,
       atoms,

--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ import Renderer_0_3, { // eslint-disable-line
 // ///////////////////////////////////////
 
 export default class MobiledocReactRenderer {
-  constructor ({ atoms = [], cards = [], markups = [] }) {
+  constructor ({ sections = [], atoms = [], cards = [], markups = [] }) {
     this.options = {
+      sections,
       atoms,
       cards,
       markups

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Renderer_0_3, { // eslint-disable-line
 } from './renderers/0-3';
 
 export default class MobiledocReactRenderer {
-  constructor ({ sections = [], atoms = [], cards = [], markups = [], additionalProps = {} }) {
+  constructor ({ sections = {}, atoms = [], cards = [], markups = [], additionalProps = {} }) {
     this.options = {
       sections,
       atoms,

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,9 @@ import Renderer_0_3, { // eslint-disable-line
 } from './renderers/0-3';
 
 export default class MobiledocReactRenderer {
-  constructor ({ atoms = [], cards = [], markups = [], additionalProps = {} }) {
+  constructor ({ sections = [], atoms = [], cards = [], markups = [], additionalProps = {} }) {
     this.options = {
+      sections,
       atoms,
       cards,
       markups,

--- a/src/renderers/0-3.js
+++ b/src/renderers/0-3.js
@@ -13,7 +13,7 @@ export const MARKUP_MARKER_TYPE = 0;
 export const ATOM_MARKER_TYPE = 1;
 
 export default class Renderer {
-  constructor (mobiledoc, { sections = [], atoms = [], cards = [], markups = [], additionalProps = {} }) {
+  constructor (mobiledoc, { sections = {}, atoms = [], cards = [], markups = [], additionalProps = {} }) {
     this.mobiledoc = mobiledoc;
     this.sections = sections;
     this.atoms = atoms;

--- a/src/renderers/0-3.js
+++ b/src/renderers/0-3.js
@@ -13,8 +13,9 @@ export const MARKUP_MARKER_TYPE = 0;
 export const ATOM_MARKER_TYPE = 1;
 
 export default class Renderer {
-  constructor (mobiledoc, { atoms = [], cards = [], markups = [], additionalProps = {} }) {
+  constructor (mobiledoc, { sections = [], atoms = [], cards = [], markups = [], additionalProps = {} }) {
     this.mobiledoc = mobiledoc;
+    this.sections = sections;
     this.atoms = atoms;
     this.cards = cards;
     this.markups = markups;
@@ -50,7 +51,12 @@ export default class Renderer {
   }
 
   renderMarkupSection ([type, TagName, markers], nodeKey) {
-    const element = <TagName key={nodeKey}>{[]}</TagName>;
+    let props;
+    if (TagName in this.sections) {
+      props = this.sections[TagName];
+    }
+
+    const element = React.createElement(TagName, {key: nodeKey, ...props}, []);
     return this.renderMarkersOnElement(element, markers);
   }
 


### PR DESCRIPTION
The changes in this repo add functionality to customize any of the markup sections. Instructions below are for verifying the whole card.

1. Checkout this branch
2. Open the folder and type `npm link`
3. Checkout this branch: https://github.com/dailybeast/thedailybeast/pull/1626
4. Open `'thedailybeast` and type `npm link @dailybeast/mobiledoc-react-renderer`
5. Run the app and view this story: http://dev.thedailybeast.com:4700/body-super-feature
6. Scroll down and verify that the h2 'Headline' matches the accent color at the top (h3 should be black)
7. Check a feature article with no accent color: http://dev.thedailybeast.com:4700/james-comeys-abc-interview-has-furious-fbi-insiders-lashing-out (h2 should be red, h3 should be black)
8. Check a regular article: http://dev.thedailybeast.com:4700/fsdfsdf-6 (h2 should be black, h3 should be red)

New sizing will be done with Dair in a new pr.