### PR TITLE
adds the ability to add a classname to the wrapping div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Renderer_0_3, { // eslint-disable-line
 } from './renderers/0-3';
 
 export default class MobiledocReactRenderer {
-  constructor ({ atoms = [], cards = [], markups = [], sections = [], additionalProps = {}, className = 'defaultNewClassName' }) {
+  constructor ({ atoms = [], cards = [], markups = [], sections = [], additionalProps = {}, className = '' }) {
     this.options = {
       atoms,
       cards,

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,13 @@ import Renderer_0_3, { // eslint-disable-line
 } from './renderers/0-3';
 
 export default class MobiledocReactRenderer {
-  constructor ({ atoms = [], cards = [], markups = [], sections = [], additionalProps = {} }) {
+  constructor ({ atoms = [], cards = [], markups = [], sections = [], additionalProps = {}, className = 'defaultNewClassName' }) {
     this.options = {
       atoms,
       cards,
       markups,
       sections,
+      className,
       additionalProps
     };
   }

--- a/src/renderers/0-3.js
+++ b/src/renderers/0-3.js
@@ -13,7 +13,14 @@ export const MARKUP_MARKER_TYPE = 0;
 export const ATOM_MARKER_TYPE = 1;
 
 export default class Renderer {
-  constructor (mobiledoc, { atoms = [], cards = [], sections = [], markups = [], className = '', additionalProps = {} }) {
+  constructor (mobiledoc, {
+    atoms = [],
+    cards = [],
+    sections = [],
+    markups = [],
+    className = 'Mobiledoc',
+    additionalProps = {}
+  }) {
     this.mobiledoc = mobiledoc;
     this.className = className;
     this.atoms = atoms;
@@ -26,7 +33,7 @@ export default class Renderer {
   }
 
   render () {
-    const renderedSections = <div className={`Mobiledoc${this.className ? ' ' + this.className : ''}`}>{this.renderSections()}</div>;
+    const renderedSections = <div className={this.className}>{this.renderSections()}</div>;
     this.renderCallbacks.forEach(cb => cb());
 
     return renderedSections;

--- a/src/renderers/0-3.js
+++ b/src/renderers/0-3.js
@@ -13,8 +13,9 @@ export const MARKUP_MARKER_TYPE = 0;
 export const ATOM_MARKER_TYPE = 1;
 
 export default class Renderer {
-  constructor (mobiledoc, { atoms = [], cards = [], sections = [], markups = [], additionalProps = {} }) {
+  constructor (mobiledoc, { atoms = [], cards = [], sections = [], markups = [], className = '', additionalProps = {} }) {
     this.mobiledoc = mobiledoc;
+    this.className = className;
     this.atoms = atoms;
     this.cards = cards;
     this.markups = markups;
@@ -25,7 +26,7 @@ export default class Renderer {
   }
 
   render () {
-    const renderedSections = <div className='Mobiledoc'>{this.renderSections()}</div>;
+    const renderedSections = <div className={`Mobiledoc${this.className ? ' ' + this.className : ''}`}>{this.renderSections()}</div>;
     this.renderCallbacks.forEach(cb => cb());
 
     return renderedSections;


### PR DESCRIPTION
This adds the ability to add custom classnames to the wrapping div of Mobiledoc. This is helpful especially in ConversionCards which is using Mobiledoc so that we could add custom styles to it.

To be fair, we don't need this change if we didn't have this rule that prevents us from being able to reference one component inside of another component's css file. For instance, this is not allowed based on the rules that we've limited ourselves to:

```css
/* ConversionCard.scss */

.ConversionCard .Mobiledoc {
  // custom styles
}
```